### PR TITLE
Introduce /auto router to cycle through random entries every X seconds

### DIFF
--- a/js/app/router/AppRouter.js
+++ b/js/app/router/AppRouter.js
@@ -11,25 +11,53 @@ define([
 
 	return Backbone.Router.extend({
 		routes: {
-			'': 'showRandomEntry',
-			'entry/:id': 'showEntry'
+			'auto(/)(:duration)': 'showAuto',
+			'entry/:id(/)(:duration)': 'showEntry',
+			'*default': 'showDefault'
 		},
 
 		initialize: function() {
 			this.entriesData = JSON.parse(data);
 			this.entries = new Entries(this.entriesData);
+			this.timeoutID = null;
 			var entriesView = new EntriesView({ collection: this.entries });
 			this.listenTo(entriesView, 'routeToUnviewedEntry', this.showEntry)
 		},
 
-		showRandomEntry: function() {
+		showDefault: function() {
+			this.stopAuto();
 			var randomEntryID = this.entries.getUnviewedEntryID();
 			this.navigate("entry/" + randomEntryID, { trigger: true });
 		},
 
-		showEntry: function(id) {
+		showAuto: function(duration) {
+			duration = duration ? duration : 30;
+			var randomEntryID = this.entries.getUnviewedEntryID();
+			this.navigate("entry/" + randomEntryID + "/" + duration, { trigger: true });
+		},
+
+		showEntry: function(id, duration) {
 			var entry = this.entries.findWhere({ id : parseInt(id) });
 			new EntryView({ model : entry }).render();
+
+			if(duration){
+				this.enableAuto(duration);
+			} else {
+				this.stopAuto();
+			}
+		},
+
+		enableAuto: function(duration){
+			var _this = this
+			this.timeoutID = setTimeout(function(){
+				var randomEntryID = _this.entries.getUnviewedEntryID();
+				_this.navigate("entry/" + randomEntryID + "/" + duration, { trigger: true });
+			}, duration * 1000);
+		},
+
+		stopAuto: function(){
+			clearTimeout(this.timeoutID);
+			this.timeoutID = null;
 		}
 
 	});


### PR DESCRIPTION
Full list of changes:
- Introduced `/auto` to cycle through random entries every X seconds
- Renamed default action to `showDefault`
- Changed default action url to get triggered as a fallback if no other action was triggered [ref](http://stackoverflow.com/questions/6088073/default-routes-in-a-backbone-js-controller)

New routes introduced:
- `/auto` will render a random Entry every 30 seconds
- `/auto/15` will render a random Entry every 15 seconds
- `/entry/8/12` will render a Entry 8 and a random Entry every 12 seconds
- `/somethingElseNotValid` will behave as the default action
