### PR TITLE
entry url: include title

### DIFF
--- a/js/app/models/Entry.js
+++ b/js/app/models/Entry.js
@@ -9,8 +9,20 @@ define([
 			if (!attrs || attrs.title === '' || attrs.description === '') {
 				return "The model must have a title and a description.";
 			}
-		}
+		},
 
+		urlFriendlyTitle: function() {
+			var title = this.get('title');
+			return this.convertToSlug(title);
+		},
+
+		// http://stackoverflow.com/questions/1053902/how-to-convert-a-title-to-a-url-slug-in-jquery#answer-1054862
+		convertToSlug: function(text) {
+			return text
+				.toLowerCase()
+				.replace(/[^\w ]+/g,'')
+				.replace(/ +/g,'-');
+		}
 	});
 
 });

--- a/js/app/router/AppRouter.js
+++ b/js/app/router/AppRouter.js
@@ -10,7 +10,7 @@ define([
 	return Backbone.Router.extend({
 		routes: {
 			'': 'showRandomEntry',
-			'entry/:id': 'showEntry'
+			'entry/:id(/:title)': 'showEntry'
 		},
 
 		initialize: function() {
@@ -27,6 +27,8 @@ define([
 
 		showEntry: function(id) {
 			var entry = this.entries.findWhere({ id : parseInt(id) });
+			this.navigate("entry/" + id + "/" +
+				entry.urlFriendlyTitle(), { trigger: true });
 			new EntryView({ model : entry }).render();
 		}
 


### PR DESCRIPTION
Added the title in the url.

converting this
http://greekintech.com/#entry/11
to 
http://greekintech.com/#entry/11/android

Concerns:
- AppRouter's `showEntry` method is called twice. This is good on the one hand since it converts urls of 
  `#entry/11-something-else` to `/#entry/11/android`, but may be wrong architecture-wise
