### PR TITLE
keyboard accessibility for site navigation

### DIFF
--- a/js/app/views/EntriesView.js
+++ b/js/app/views/EntriesView.js
@@ -5,7 +5,8 @@ define([
 	return Backbone.View.extend({
 		el: $('body'),
 		events: {
-			'click' : "renderRandomEntry"
+			'click' : 'renderRandomEntry',
+			'keydown' : 'handleKeyboardEvent'
 		},
 
 		initialize: function(options) {
@@ -13,11 +14,30 @@ define([
 		},
 
 		renderRandomEntry: function(e) {
-			if (!$(e.target).is('a')) { // TODO find a better way to suppress event delegation
-				var unviewedEntry = this.collection.getUnviewedEntryID();
-				this.trigger('routeToUnviewedEntry', unviewedEntry);
+			// TODO find a better way to suppress event delegation
+			if (e && $(e.target).is('a')) {
+				return;
 			}
-		}
+			var unviewedEntry = this.collection.getUnviewedEntryID();
+			this.trigger('routeToUnviewedEntry', unviewedEntry);
+		},
 
+		handleKeyboardEvent: function(e, b) {
+			// http://www.javascriptkeycode.com/
+			var backKeys = [37, 72], forwardKeys = [39, 76], space = [32];
+
+			if (!_.contains(_.union(backKeys, forwardKeys, space), e.keyCode)){
+				return;
+			}
+
+			var isForward = _.contains(forwardKeys, e.keyCode) ||
+				(space == e.keyCode && !e.shiftKey);
+			this.moveToEntry(isForward);
+			e.preventDefault();
+		},
+
+		moveToEntry: function(isForward) {
+			isForward ? this.renderRandomEntry() : window.history.back();
+		},
 	});
 });


### PR DESCRIPTION
Added keyboard accessibility.

Go forward
- right arrow
- L (in tribute of [Vim](http://vim.rtorr.com/))
- Space

Go back
- left arrow
- H (in tribute of [Vim](http://vim.rtorr.com/))
- Shift+Space

**Concern**: If a user goes back and then forth, he will not land on the same entry. However, having the forward movement moving in history (instead of entries) means that the keyboard can not be used to create new entries.
